### PR TITLE
Mac Notification Center

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,15 @@ name := "sbt-growl-plugin"
 organization := "me.lessis"
 
 version <<= sbtVersion(v =>
-  if (v.startsWith("0.11") || v.startsWith("0.12") || v.startsWith("0.13")) "0.1.3"
+  if (v.startsWith("0.11") || v.startsWith("0.12") || v.startsWith("0.13")) "0.1.4-SNAPSHOT"
   else error("unsupported sbt version %s" format v)
 )
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
-sbtVersion in Global := "0.13.0-RC1"
+sbtVersion in Global := "0.13.6"
 
-scalaVersion in Global := "2.10.2"
+scalaVersion in Global := "2.10.4"
 
 resolvers += Opts.resolver.sonatypeReleases
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.6

--- a/src/main/scala/GrowlingTests.scala
+++ b/src/main/scala/GrowlingTests.scala
@@ -2,7 +2,7 @@ package growl
 
 import sbt._
 import Keys._
-import sbt.Project.Initialize
+import sbt.Def.Initialize
 
 object GrowlingTests extends sbt.Plugin {
   import GrowlKeys._
@@ -16,9 +16,9 @@ object GrowlingTests extends sbt.Plugin {
     val growler = SettingKey[Growler]("growler", "Interface used to growl test results at users.  RRRRRRRRR!")
   }
 
-  val Growl = config("growl")
+  val Growl = config("growl") extend(Test)
 
-//  override val settings = super.settings ++ growlSettings
+  override lazy val projectSettings = growlSettings
 
   private def growlingTestListenerTask: Def.Initialize[sbt.Task[sbt.TestReportListener]] =
     (groupFormatter in Growl, exceptionFormatter in Growl, aggregateFormatter in Growl, growler in Growl, streams) map {


### PR DESCRIPTION
Depends on @worrel's PR, simply because I'm using SBT 0.13 and Java 8, and the project as currently in master does not support either.

This PR adds support for Mac's Notification Center via the excellent [`terminal-notifier`][https://github.com/alloy/terminal-notifier] utility.  You will need the command installed if you want to use this plugin (hint: `sudo gem install terminal-notifier`).
