### PR TITLE
Added growlGroup & growlAggregate settings.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ version <<= sbtVersion(v =>
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
-sbtVersion in Global := "0.13.0-RC1"
+sbtVersion in Global := "0.13.7"
 
 scalaVersion in Global := "2.10.2"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.7

--- a/src/main/scala/GrowlingTests.scala
+++ b/src/main/scala/GrowlingTests.scala
@@ -14,6 +14,8 @@ object GrowlingTests extends sbt.Plugin {
     val aggregateFormatter = SettingKey[(AggregateResult => GrowlResultFormat)]("aggregate-formatter", "Function used to format an aggregation of test results.")
     val defaultImagePath = SettingKey[File]("default-image-path", "Default path used to resolve growl test images.")
     val growler = SettingKey[Growler]("growler", "Interface used to growl test results at users.  RRRRRRRRR!")
+    val growlGroup = SettingKey[Boolean]("growl-group", "Growl group results")
+    val growlAggregate = SettingKey[Boolean]("growl-aggregate", "Growl aggregate results")
   }
 
   val Growl = config("growl")
@@ -21,9 +23,9 @@ object GrowlingTests extends sbt.Plugin {
 //  override val settings = super.settings ++ growlSettings
 
   private def growlingTestListenerTask: Def.Initialize[sbt.Task[sbt.TestReportListener]] =
-    (groupFormatter in Growl, exceptionFormatter in Growl, aggregateFormatter in Growl, growler in Growl, streams) map {
-      (resFmt, expFmt, aggrFmt, growler, out) =>
-        new GrowlingTestsListener(resFmt, expFmt, aggrFmt, growler, out.log)
+    (groupFormatter in Growl, exceptionFormatter in Growl, aggregateFormatter in Growl, growler in Growl, streams, growlGroup in Growl, growlAggregate in Growl) map {
+      (resFmt, expFmt, aggrFmt, growler, out, growlGroup, growlAggregate) =>
+        new GrowlingTestsListener(resFmt, expFmt, aggrFmt, growler, out.log, growlGroup, growlAggregate)
     }
 
   val growlSettings: Seq[Setting[_]] = inConfig(Growl)(Seq(
@@ -88,7 +90,9 @@ object GrowlingTests extends sbt.Plugin {
             }
           )
     },
-    defaultImagePath := file(System.getProperty("user.home")) / ".sbt" / "growl" / "icons"
+    defaultImagePath := file(System.getProperty("user.home")) / ".sbt" / "growl" / "icons",
+    growlGroup := true,
+    growlAggregate := true
   )) ++ Seq(
     testListeners <+= growlingTestListenerTask
   )

--- a/src/main/scala/GrowlingTestsListener.scala
+++ b/src/main/scala/GrowlingTestsListener.scala
@@ -40,7 +40,7 @@ class GrowlingTestsListener(
   groupFormatter: GroupResult => GrowlResultFormat,
   exceptionFormatter:(String, Throwable) => GrowlResultFormat,
   aggregateFormatter: AggregateResult => GrowlResultFormat,
-  growler: Growler, log: sbt.Logger) extends TestsListener {
+  growler: Growler, log: sbt.Logger, growlGroup: Boolean, growlAggregate: Boolean) extends TestsListener {
 
   private var skipped, errors, passed, failures = 0
 
@@ -66,16 +66,24 @@ class GrowlingTestsListener(
 
 
   /** called when test group is completed */
-  def endGroup(name: String, result: TestResult.Value) =
-    growler.notify(groupFormatter(GroupResult(name, result)))
+  def endGroup(name: String, result: TestResult.Value) = {
+    if (growlGroup) {
+      growler.notify(groupFormatter(GroupResult(name, result)))
+    }
+  }
 
   /** called when all tests are complete */
   def doComplete(status: TestResult.Value) = {
-		val all = failures + errors + skipped + passed
-    growler.notify(aggregateFormatter(AggregateResult(status, all, failures, errors, passed, skipped)))
+    if (growlAggregate) {
+      val all = failures + errors + skipped + passed
+      growler.notify(aggregateFormatter(AggregateResult(status, all, failures, errors, passed, skipped)))
+    }
 	}
 
   /** called if there was an error during test */
-  def endGroup(name: String, t: Throwable) =
-    growler.notify(exceptionFormatter(name, t))
+  def endGroup(name: String, t: Throwable) = {
+    if (growlGroup) {
+      growler.notify(exceptionFormatter(name, t))
+    }
+  }
 }


### PR DESCRIPTION
If growlGroup is set to false, then the results are not growled for groups
If growlAggregate is set to false, the the results are not growled for the aggregate.

Both settings are true by default.

Justification: libnotify notifications can be quite slow to disappear - notify-osd ignores the timeout parameter. So growling each test isn't useful. The aggregate is fine
